### PR TITLE
Fix three WebUI runtime bugs from front-end review

### DIFF
--- a/WebUI/src/views/HomeView.vue
+++ b/WebUI/src/views/HomeView.vue
@@ -369,7 +369,7 @@ async function toggleMute() {
     console.error('Failed to toggle mute:', error);
     errorMessage.value = `Failed to toggle mute: ${error.message}`;
     // Revert state on error
-    muteEnabled.value = !newState;
+    muteEnabled.value = !muteEnabled.value;
   }
 }
 
@@ -404,7 +404,7 @@ async function restoreConfiguration() {
       const formData = new FormData();
       formData.append('file', file);
       try {
-        apiClient.restore(formData);
+        await apiClient.restore(formData);
         alert('Configuration restore initiated. The device will now reboot. The page will reload automatically to reflect the restored state.');
         setTimeout(() => {
           window.location.reload();

--- a/WebUI/src/views/PresetEditorView.vue
+++ b/WebUI/src/views/PresetEditorView.vue
@@ -113,13 +113,13 @@
       :confirm-text="modalState.confirmText"
       @confirm="handleModalConfirm"
     >
-      <InputGroup v-model="modalState.inputValue" :placeholder="modalState.placeholder" class="w-full mb-4" />
+      <InputGroup ref="newPresetNameInput" v-model="modalState.inputValue" :placeholder="modalState.placeholder" class="w-full mb-4" />
     </ModalDialog>
   </div>
 </template>
 
 <script setup>
-import { ref, reactive, onMounted, inject, onUnmounted } from 'vue';
+import { ref, reactive, onMounted, inject, onUnmounted, nextTick } from 'vue';
 import { asyncDebounce } from '../utilities.js'; // [cite: 42] Utility for rate limiting function calls
 import RangeSlider from '../components/shared/RangeSlider.vue';
 import InputGroup from '../components/shared/InputGroup.vue';
@@ -182,6 +182,7 @@ const modalState = reactive({
   sourceName: '', // For rename/copy operations
 });
 const showModal = ref(false); // Controls visibility of the unified modal
+const newPresetNameInput = ref(null); // Ref to the preset name input in the modal
 
 // Preset-specific editable properties
 const speakerDelays = reactive({ left: 0, right: 0, sub: 0 }); // Speaker delays [cite: 49]
@@ -464,10 +465,9 @@ async function openPresetModal(type, name) {
   modalState.sourceName = name;
   showModal.value = true;
 
-  //On next tick, focus the input field and select all text
+  //On next tick, focus the input field
   nextTick(() => {
-    newPresetNameInput.value.focus();
-    newPresetNameInput.value.select();
+    newPresetNameInput.value?.focus();
   });
 }
 


### PR DESCRIPTION
- HomeView toggleMute(): error path referenced undefined newState, throwing a ReferenceError instead of reverting the toggle; revert by negating muteEnabled instead.
- PresetEditorView openPresetModal(): nextTick was not imported and newPresetNameInput was never declared, so rename/copy preset threw; import nextTick, add the ref to the modal InputGroup, and call its exposed focus() (InputGroup exposes no select()).
- HomeView restoreConfiguration(): apiClient.restore() was not awaited, so the expected reboot error escaped the try/catch as an unhandled rejection; add await.